### PR TITLE
Do critical update if current app version is smaller than latest critical update version

### DIFF
--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -36,6 +36,33 @@ class Appcast {
   late IosDeviceInfo _iosInfo;
   String? osVersionString;
 
+  /// Returns the latest item in the Appcast, including only critical updates.
+  AppcastItem? criticalUpdateItem() {
+    if (items == null) {
+      return null;
+    }
+
+    AppcastItem? bestItem;
+    items!.forEach((AppcastItem item) {
+      if (item.hostSupportsItem(osVersion: osVersionString) && item.isCriticalUpdate) {
+        if (bestItem == null) {
+          bestItem = item;
+        } else {
+          try {
+            final itemVersion = Version.parse(item.versionString!);
+            final bestItemVersion = Version.parse(bestItem!.versionString!);
+            if (itemVersion > bestItemVersion) {
+              bestItem = item;
+            }
+          } on Exception catch (e) {
+            print('appcast.bestItem: invalid version: $e');
+          }
+        }
+      }
+    });
+    return bestItem;
+  }
+
   /// Returns the latest item in the Appcast based on OS, OS version, and app
   /// version.
   AppcastItem? bestItem() {

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -256,6 +256,7 @@ class Upgrader {
         var count = appcast.items == null ? 0 : appcast.items!.length;
         print('upgrader: appcast item count: $count');
       }
+      final criticalUpdateItem = appcast.criticalUpdateItem();
       final bestItem = appcast.bestItem();
       if (bestItem != null &&
           bestItem.versionString != null &&
@@ -263,12 +264,20 @@ class Upgrader {
         if (debugLogging) {
           print(
               'upgrader: appcast best item version: ${bestItem.versionString}');
+          print(
+              'upgrader: appcast critical update item version: ${criticalUpdateItem?.versionString}');
         }
-        _appStoreVersion ??= bestItem.versionString;
-        _appStoreListingURL ??= bestItem.fileURL;
-        if (bestItem.isCriticalUpdate) {
+
+        final packageInfo = await PackageInfo.fromPlatform();
+        final appVersion = packageInfo.version;
+
+        final criticalVersion = criticalUpdateItem?.versionString ?? '';
+        if (criticalVersion.isNotEmpty && Version.parse(appVersion) < Version.parse(criticalVersion)) {
           _isCriticalUpdate = true;
         }
+        
+        _appStoreVersion ??= bestItem.versionString;
+        _appStoreListingURL ??= bestItem.fileURL;
         _releaseNotes = bestItem.itemDescription;
       }
     } else {


### PR DESCRIPTION
This PR fixes an issue when the appcast contains both critical updates and regular updates, and critical update version is lower than the regular update version, Apps lower than critical version fails to act as a critical update.
i.e.
Suppose critical update version is 0.13.0, regular update version is 0.14.0. 
If app version is 0.12.0, it offers update to 0.14.0 but the Ignore / Later buttons still show.
After this PR, upgrader should offer update to 0.14.0 and do not show the Ignore / Later buttons.